### PR TITLE
Make libavformat the default demuxer

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -853,7 +853,7 @@ namespace WebMConverter
             });
             indexbw.DoWork += delegate(object sender, DoWorkEventArgs e)
             {
-                FFMSSharp.Indexer indexer = new FFMSSharp.Indexer(path);
+                FFMSSharp.Indexer indexer = new FFMSSharp.Indexer(path, FFMSSharp.Source.Lavf);
 
                 indexer.UpdateIndexProgress += delegate(object sendertwo, FFMSSharp.IndexingProgressChangeEventArgs etwo)
                 {


### PR DESCRIPTION
This shouldn't pose any kind of problem, and not having it the default makes opening MKVs containing Fraps video codec crash.
